### PR TITLE
[GAG-10610] Amplify Rails upgrade - additional tasks 2

### DIFF
--- a/apivore.gemspec
+++ b/apivore.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rspec', '~> 3.12'
   s.add_runtime_dependency 'rspec-expectations', '~> 3.1'
   s.add_runtime_dependency 'rspec-mocks', '~> 3.1'
-  s.add_runtime_dependency 'hashie', '~> 3.3'
+  s.add_runtime_dependency 'hashie', '~> 5.0'
   s.add_development_dependency 'pry', '~> 0'
   s.add_development_dependency 'rake', '~> 12.2'
   s.add_development_dependency 'rspec-rails', '~> 6'

--- a/apivore.gemspec
+++ b/apivore.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/westfieldlabs/apivore'
   s.licenses    = ['Apache 2.0']
 
-  s.add_runtime_dependency 'json-schema', '~> 2.5'
+  s.add_runtime_dependency 'json-schema', '~> 4'
   s.add_runtime_dependency 'rspec', '~> 3.12'
   s.add_runtime_dependency 'rspec-expectations', '~> 3.1'
   s.add_runtime_dependency 'rspec-mocks', '~> 3.1'

--- a/lib/apivore/version.rb
+++ b/lib/apivore/version.rb
@@ -1,3 +1,3 @@
 module Apivore
-  VERSION = '2.0.1.rc1'
+  VERSION = '2.0.1.rc2'
 end

--- a/lib/apivore/version.rb
+++ b/lib/apivore/version.rb
@@ -1,3 +1,3 @@
 module Apivore
-  VERSION = '2.0.0'
+  VERSION = '2.0.1.rc1'
 end


### PR DESCRIPTION
References: [GAG-10610], [GAG-9488]

This PR updates `hashie` dependency to ensure compatibility with Ruby 3 and Rails 6

[GAG-10610]: https://gaggleamp.atlassian.net/browse/GAG-10610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GAG-9488]: https://gaggleamp.atlassian.net/browse/GAG-9488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ